### PR TITLE
[codex] Expand Ladle component catalog stories

### DIFF
--- a/docs/doc-hub.html
+++ b/docs/doc-hub.html
@@ -700,7 +700,7 @@
                 <h3>Component Catalog</h3>
                 <span class="badge">Ladle</span>
               </div>
-              <p>Ladleで確認するReactコンポーネント、5状態、fixture、Framer実機との境界。</p>
+              <p>Ladleで確認するReactコンポーネント、5状態、editor interaction story、fixture、Framer実機との境界。</p>
             </div>
           </a>
           <a class="doc-card compact ui" href="mockups/screen-flow-concept.html">

--- a/docs/specs/11-component-catalog.md
+++ b/docs/specs/11-component-catalog.md
@@ -58,14 +58,18 @@ npm run catalog:build
 
 | Component | 実装 | Story | Figma | 状態 | メモ |
 |---|---|---|---|---|---|
-| `AppHeader` | `src/components/AppHeader.tsx` | TBD | TBD | default | title と language toggle を管理する。 |
-| `LanguageToggle` | `src/components/LanguageToggle.tsx` | TBD | Framer `Gd3hmibM4` | default / selected-ja / focus-visible | `48x24px` track、`20px` thumb。Framer MCP の選択ノード値を基準にする。 |
+| `AppHeader` | `src/components/AppHeader.tsx` | `src/components/AppHeader.stories.tsx` | TBD | default / selected-ja | title と language toggle をまとめて確認する。 |
+| `LanguageToggle` | `src/components/LanguageToggle.tsx` | `src/components/LanguageToggle.stories.tsx` | Framer `Gd3hmibM4` | default / selected-ja / focus-visible | `52x26px` track、`22px` thumb。selected-ja と focus-visible を個別 story で確認する。 |
 | `ActionButton` | `src/components/ui.tsx` | `src/components/ui.stories.tsx` | button component | default / hover / active / disabled / focus-visible | CV button を base とする。`variant` と `size` で管理する。 |
 | `FileButton` | `src/components/ui.tsx` | `src/components/ui.stories.tsx` | button component | default / hover / active / focus-within | file input を ActionButton と同じ size scale に揃える。 |
 | `SelectControl` | `src/components/ui.tsx` | `src/components/ui.stories.tsx` | TBD | default / focus-visible | import strategy などの select を管理する。 |
-| `JsonTokenEditor` | `src/components/JsonTokenEditor.tsx` | `src/components/JsonTokenEditor.stories.tsx` | editor component | default / focused / diagnostic / copied / tooltip | JSON editor、copy、resize、inline diagnostic を含む。 |
-| `StatsGrid` | `src/components/StatsGrid.tsx` | TBD | TBD | default | token counts を表示する。 |
-| `TokenCard` / `TokenCardList` | `src/components/TokenCard.tsx`, `src/components/TokenCardList.tsx` | `src/components/TokenCard.stories.tsx` | TBD | ideal / empty / loading / partial / error / selected / focus-visible | import preview と conflict choice を表示する。 |
+| `SectionTitle` / `HelperText` | `src/components/ui.tsx` | `src/components/ui-primitives.stories.tsx` | TBD | default | 見出しと補助文の組み合わせを確認する。 |
+| `MessageBox` | `src/components/ui.tsx` | `src/components/ui-primitives.stories.tsx` | TBD | warning / danger | notice と error の見え分けを固定 fixture で確認する。 |
+| `DialogBackdrop` / `DialogPanel` / `DialogActions` | `src/components/ui.tsx` | `src/components/ui-primitives.stories.tsx` | TBD | modal shell | import result modal の土台を確認する。 |
+| `JsonTokenEditor` | `src/components/JsonTokenEditor.tsx` | `src/components/JsonTokenEditor.stories.tsx` | editor component | default / focused / diagnostic / copied / tooltip | JSON editor、copy、resize、inline diagnostic を含む。focused 用に `focus-within` ring を持つ。 |
+| `StatsGrid` | `src/components/StatsGrid.tsx` | `src/components/StatsGrid.stories.tsx` | TBD | default / long-label-large-number | token counts を表示する。長いラベルと大きい数値の折り返しも確認する。 |
+| `TokenCard` | `src/components/TokenCard.tsx` | `src/components/TokenCardSingle.stories.tsx` | TBD | default / selected / conflict / focus-visible | isolated card として選択状態、既存 style conflict、focus ring を確認する。 |
+| `TokenCardList` | `src/components/TokenCardList.tsx` | `src/components/TokenCard.stories.tsx` | TBD | ideal / empty / loading / partial / error | import preview と conflict choice を表示する。 |
 | `ImportSummary` | `src/components/ImportSummary.tsx` | `src/components/ImportSummary.stories.tsx` | TBD | success / failed | import result modal の内容を表示する。 |
 
 ## UI stack
@@ -82,6 +86,17 @@ npm run catalog:build
 ## Story fixture
 
 `src/components/catalog.fixtures.ts` は Ladle 専用の軽量 fixture。実 Framer API の戻り値ではなく、表示状態を固定して確認するための mock data として扱う。
+
+| Story | Fixture | 確認観点 |
+|---|---|---|
+| `AppHeader / Default`, `AppHeader / Japanese selected` | inline title string | title と language toggle の横並びバランスを確認する。 |
+| `LanguageToggle / Default`, `Japanese selected`, `FocusVisible` | local state | 英日切替と focus ring を固定 view で確認する。 |
+| `StatsGrid / Default` | `catalogStatsItems` | 基本の件数表示を確認する。 |
+| `StatsGrid / Long label / large number` | `catalogStatsItemsLongLabel` | 長いラベルと3桁値の折り返しを確認する。 |
+| `TokenCard / Default`, `Selected`, `FocusVisible` | `catalogTokenCardRows`, `catalogTokenCardModeRows` | 単体 card の badge、mode、選択状態を確認する。 |
+| `TokenCard / Conflict` | inline existing style row | 既存 style collision を isolated card で確認する。 |
+| `JsonTokenEditor / Default`, `Focused state`, `Copied state`, `Tooltip state` | `catalogEditorJson` | text focus、copy feedback、hover tooltip を story ごとに確認する。 |
+| `JsonTokenEditor / Diagnostic state` | `catalogEditorJson`, `catalogEditorDiagnostics` | 変換 notice と unsupported value error の混在を確認する。 |
 
 ## Button API
 
@@ -111,7 +126,7 @@ Typography は component 固有値ではなく `src/tokens.css` の semantic uti
 
 ## 今後の追加候補
 
-- `JsonTokenEditor` の copied / tooltip interaction を Playwright で確認しやすい story に分ける。
-- `LanguageToggle` と `StatsGrid` の story を追加する。
+- `JsonTokenEditor` の copied / tooltip story を `npm run screenshots` の capture 対象へ追加する。
+- `AppHeader` と `LanguageToggle` に Figma node ID または比較画像を紐づける。
 - Figma MCP の上限解除後、各 component に Figma node ID を紐づける。
 - light / dark 対応時に、ここへ theme token の適用状況を追加する。

--- a/src/components/AppHeader.stories.tsx
+++ b/src/components/AppHeader.stories.tsx
@@ -1,0 +1,43 @@
+import { action } from "@ladle/react"
+import { useState } from "react"
+import type { StoryDefault } from "@ladle/react"
+import type { ReactNode } from "react"
+import { AppHeader } from "./AppHeader.tsx"
+import "../tokens.css"
+
+export default {
+  title: "Components / AppHeader",
+} satisfies StoryDefault
+
+function HeaderSurface({ children }: { children: ReactNode }) {
+  return (
+    <main className="min-h-screen bg-neutral-950 p-6 text-neutral-100">
+      <div className="mx-auto flex max-w-[420px] flex-col gap-4 rounded-[24px] border border-neutral-700 bg-neutral-900 p-4 shadow-2xl">
+        {children}
+      </div>
+    </main>
+  )
+}
+
+function HeaderStory({ initialLanguage }: { initialLanguage: "en" | "ja" }) {
+  const [language, setLanguage] = useState<"en" | "ja">(initialLanguage)
+
+  return (
+    <HeaderSurface>
+      <AppHeader
+        language={language}
+        title="Token Color Styles Importer"
+        onLanguageChange={nextLanguage => {
+          setLanguage(nextLanguage)
+          action("language-change")(nextLanguage)
+        }}
+      />
+    </HeaderSurface>
+  )
+}
+
+export const Default = () => <HeaderStory initialLanguage="en" />
+
+export const JapaneseSelected = () => <HeaderStory initialLanguage="ja" />
+
+JapaneseSelected.storyName = "Japanese selected"

--- a/src/components/JsonTokenEditor.stories.tsx
+++ b/src/components/JsonTokenEditor.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from "@ladle/react"
-import { useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import type { StoryDefault } from "@ladle/react"
-import type { ReactNode } from "react"
+import type { ReactNode, RefObject } from "react"
 import type { EditorDiagnostic } from "./JsonTokenEditor.tsx"
 import { JsonTokenEditor } from "./JsonTokenEditor.tsx"
 import {
@@ -21,9 +21,15 @@ const editorLabels = {
   resize: "エディタの高さを変更",
 }
 
-function EditorSurface({ children }: { children: ReactNode }) {
+function EditorSurface({
+  children,
+  surfaceRef,
+}: {
+  children: ReactNode
+  surfaceRef?: RefObject<HTMLElement>
+}) {
   return (
-    <main className="min-h-screen bg-neutral-950 p-6 text-neutral-100">
+    <main className="min-h-screen bg-neutral-950 p-6 text-neutral-100" ref={surfaceRef}>
       <div className="flex max-w-[640px] flex-col gap-3">
         <h2 className="m-0 text-xs font-semibold leading-tight text-neutral-300">JsonTokenEditor</h2>
         {children}
@@ -35,19 +41,68 @@ function EditorSurface({ children }: { children: ReactNode }) {
 function EditorStory({
   diagnostics = [],
   initialValue = catalogEditorJson,
+  mode = "default",
 }: {
   diagnostics?: EditorDiagnostic[]
   initialValue?: string
+  mode?: "copied" | "default" | "focused" | "tooltip"
 }) {
   const [value, setValue] = useState(initialValue)
+  const surfaceRef = useRef<HTMLElement>(null)
   const lineNumbersRef = useRef<HTMLDivElement | null>(null)
   const lineNumbers = useMemo(
     () => Array.from({ length: value.split("\n").length }, (_, index) => index + 1),
     [value]
   )
 
+  useEffect(() => {
+    if (mode !== "focused") return
+
+    const textarea = surfaceRef.current?.querySelector<HTMLTextAreaElement>('textarea[aria-label="JSON token source"]')
+    textarea?.focus()
+  }, [mode])
+
+  useEffect(() => {
+    if (mode !== "tooltip") return
+
+    const button = surfaceRef.current?.querySelector<HTMLButtonElement>('button[aria-label="JSONをコピー"]')
+    if (!button) return
+
+    button.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
+
+    return () => {
+      button.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }))
+    }
+  }, [mode])
+
+  useEffect(() => {
+    if (mode !== "copied") return
+
+    const button = surfaceRef.current?.querySelector<HTMLButtonElement>('button[aria-label="JSONをコピー"]')
+    if (!button) return
+
+    const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard")
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async () => undefined,
+      },
+    })
+
+    button.click()
+
+    return () => {
+      if (originalClipboard) {
+        Object.defineProperty(navigator, "clipboard", originalClipboard)
+        return
+      }
+
+      Reflect.deleteProperty(navigator, "clipboard")
+    }
+  }, [mode])
+
   return (
-    <EditorSurface>
+    <EditorSurface surfaceRef={surfaceRef}>
       <JsonTokenEditor
         diagnostics={diagnostics}
         labels={editorLabels}
@@ -70,6 +125,18 @@ function EditorStory({
 }
 
 export const Default = () => <EditorStory />
+
+export const FocusedState = () => <EditorStory mode="focused" />
+
+FocusedState.storyName = "Focused state"
+
+export const CopiedState = () => <EditorStory mode="copied" />
+
+CopiedState.storyName = "Copied state"
+
+export const TooltipState = () => <EditorStory mode="tooltip" />
+
+TooltipState.storyName = "Tooltip state"
 
 export const DiagnosticState = () => (
   <EditorStory diagnostics={catalogEditorDiagnostics} />

--- a/src/components/JsonTokenEditor.tsx
+++ b/src/components/JsonTokenEditor.tsx
@@ -266,7 +266,7 @@ export function JsonTokenEditor({
 
   return (
     <div
-      className="relative grid min-h-[180px] w-full grid-cols-[48px_minmax(0,1fr)] overflow-hidden rounded border border-neutral-200 bg-neutral-700"
+      className="relative grid min-h-[180px] w-full grid-cols-[48px_minmax(0,1fr)] overflow-hidden rounded border border-neutral-200 bg-neutral-700 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-yellow-300"
       data-json-editor="true"
       ref={editorRef}
       style={{ height: editorHeight }}

--- a/src/components/LanguageToggle.stories.tsx
+++ b/src/components/LanguageToggle.stories.tsx
@@ -1,0 +1,62 @@
+import { action } from "@ladle/react"
+import { useState } from "react"
+import type { StoryDefault } from "@ladle/react"
+import type { ReactNode } from "react"
+import { LanguageToggle } from "./LanguageToggle.tsx"
+import "../tokens.css"
+
+export default {
+  title: "Components / LanguageToggle",
+} satisfies StoryDefault
+
+function ToggleSurface({
+  children,
+  forceFocusRing = false,
+}: {
+  children: ReactNode
+  forceFocusRing?: boolean
+}) {
+  return (
+    <main className="grid min-h-screen place-items-center bg-neutral-950 p-6 text-neutral-100">
+      <div
+        className={
+          forceFocusRing
+            ? "[&_button]:outline-2 [&_button]:outline-offset-2 [&_button]:outline-yellow-300"
+            : undefined
+        }
+      >
+        {children}
+      </div>
+    </main>
+  )
+}
+
+function ToggleStory({
+  initialLanguage,
+  forceFocusRing = false,
+}: {
+  initialLanguage: "en" | "ja"
+  forceFocusRing?: boolean
+}) {
+  const [language, setLanguage] = useState<"en" | "ja">(initialLanguage)
+
+  return (
+    <ToggleSurface forceFocusRing={forceFocusRing}>
+      <LanguageToggle
+        language={language}
+        onLanguageChange={nextLanguage => {
+          setLanguage(nextLanguage)
+          action("language-change")(nextLanguage)
+        }}
+      />
+    </ToggleSurface>
+  )
+}
+
+export const Default = () => <ToggleStory initialLanguage="en" />
+
+export const JapaneseSelected = () => <ToggleStory initialLanguage="ja" />
+
+JapaneseSelected.storyName = "Japanese selected"
+
+export const FocusVisible = () => <ToggleStory initialLanguage="en" forceFocusRing />

--- a/src/components/StatsGrid.stories.tsx
+++ b/src/components/StatsGrid.stories.tsx
@@ -1,0 +1,34 @@
+import type { StoryDefault } from "@ladle/react"
+import type { ReactNode } from "react"
+import { StatsGrid } from "./StatsGrid.tsx"
+import {
+  catalogStatsItems,
+  catalogStatsItemsLongLabel,
+} from "./catalog.fixtures.ts"
+import "../tokens.css"
+
+export default {
+  title: "Components / StatsGrid",
+} satisfies StoryDefault
+
+function StatsSurface({ children }: { children: ReactNode }) {
+  return (
+    <main className="min-h-screen bg-neutral-950 p-6 text-neutral-100">
+      <div className="max-w-[420px]">{children}</div>
+    </main>
+  )
+}
+
+export const Default = () => (
+  <StatsSurface>
+    <StatsGrid items={catalogStatsItems} />
+  </StatsSurface>
+)
+
+export const LongLabelLargeNumber = () => (
+  <StatsSurface>
+    <StatsGrid items={catalogStatsItemsLongLabel} />
+  </StatsSurface>
+)
+
+LongLabelLargeNumber.storyName = "Long label / large number"

--- a/src/components/TokenCard.tsx
+++ b/src/components/TokenCard.tsx
@@ -30,7 +30,7 @@ export function TokenCard({
   const inner = (
     <div
       className={cx(
-        "flex items-center gap-3 rounded border px-3 py-2.5",
+        "flex items-center gap-3 rounded border px-3 py-2.5 has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-yellow-300",
         hasRadio && checked
           ? "border-yellow-700/60 bg-yellow-950/50"
           : "border-neutral-600 bg-neutral-700"

--- a/src/components/TokenCardSingle.stories.tsx
+++ b/src/components/TokenCardSingle.stories.tsx
@@ -1,0 +1,75 @@
+import { action } from "@ladle/react"
+import type { StoryDefault } from "@ladle/react"
+import type { ReactNode } from "react"
+import { TokenCard } from "./TokenCard.tsx"
+import {
+  catalogTokenCardModeRows,
+  catalogTokenCardRows,
+} from "./catalog.fixtures.ts"
+import "../tokens.css"
+
+export default {
+  title: "Components / TokenCard",
+} satisfies StoryDefault
+
+function CardSurface({
+  children,
+  forceFocusRing = false,
+}: {
+  children: ReactNode
+  forceFocusRing?: boolean
+}) {
+  return (
+    <main className="min-h-screen bg-neutral-950 p-6 text-neutral-100">
+      <div
+        className={`max-w-[420px] ${forceFocusRing ? "[&_label>div]:outline-2 [&_label>div]:outline-offset-2 [&_label>div]:outline-yellow-300" : ""}`}
+      >
+        {children}
+      </div>
+    </main>
+  )
+}
+
+export const Default = () => (
+  <CardSurface>
+    <TokenCard badge={{ lightColor: "#2f6bff" }} rows={catalogTokenCardRows} />
+  </CardSurface>
+)
+
+export const Selected = () => (
+  <CardSurface>
+    <TokenCard
+      badge={{ lightColor: "#ffffff", darkColor: "#111313" }}
+      rows={catalogTokenCardModeRows}
+      radioName="semantic/background/primary"
+      radioValue="semantic-background-primary"
+      checked
+      onChange={action("select-token")}
+    />
+  </CardSurface>
+)
+
+export const Conflict = () => (
+  <CardSurface>
+    <TokenCard
+      badge={{ lightColor: "#1d4ed8" }}
+      rows={[{ value: "#1d4ed8", name: "primitive/blue/500" }]}
+      label="既存のスタイル"
+      radioName="primitive/blue/500"
+      radioValue="existing"
+      onChange={action("select-existing-style")}
+    />
+  </CardSurface>
+)
+
+export const FocusVisible = () => (
+  <CardSurface forceFocusRing>
+    <TokenCard
+      badge={{ lightColor: "#ffffff", darkColor: "#111313" }}
+      rows={catalogTokenCardModeRows}
+      radioName="semantic/background/primary"
+      radioValue="semantic-background-primary"
+      onChange={action("focus-token")}
+    />
+  </CardSurface>
+)

--- a/src/components/catalog.fixtures.ts
+++ b/src/components/catalog.fixtures.ts
@@ -5,6 +5,7 @@ import type {
   ParsedColorToken,
 } from "../lib/types/tokens.ts"
 import type { EditorDiagnostic } from "./JsonTokenEditor.tsx"
+import type { TokenCardRow } from "./TokenCard.tsx"
 
 export const catalogEditorJson = `{
   "color": {
@@ -130,6 +131,40 @@ export const catalogExistingConflicts: ColorStyleConflict[] = [
     styleName: "primitive/blue/500",
     existingPath: "primitive/blue/500",
     existingValue: "#1d4ed8",
+  },
+]
+
+export const catalogStatsItems = [
+  { label: "Color tokens", value: 12 },
+  { label: "Create", value: 8 },
+  { label: "Replace", value: 2 },
+  { label: "Skip", value: 1 },
+]
+
+export const catalogStatsItemsLongLabel = [
+  { label: "Imported semantic color tokens", value: 124 },
+  { label: "Existing styles with replacements", value: 32 },
+  { label: "Conflicts requiring user choice", value: 7 },
+  { label: "Warnings kept as notices", value: 18 },
+]
+
+export const catalogTokenCardRows: TokenCardRow[] = [
+  {
+    value: "#2f6bff",
+    name: "color.primitive.blue.500",
+  },
+]
+
+export const catalogTokenCardModeRows: TokenCardRow[] = [
+  {
+    mode: "Light",
+    value: "#ffffff",
+    name: "color.semantic.background.primary",
+  },
+  {
+    mode: "Dark",
+    value: "#111313",
+    name: "color.semantic.background.primary.dark",
   },
 ]
 

--- a/src/components/ui-primitives.stories.tsx
+++ b/src/components/ui-primitives.stories.tsx
@@ -1,0 +1,74 @@
+import { action } from "@ladle/react"
+import type { StoryDefault } from "@ladle/react"
+import type { ReactNode } from "react"
+import {
+  ActionButton,
+  DialogActions,
+  DialogBackdrop,
+  DialogPanel,
+  HelperText,
+  MessageBox,
+  SectionTitle,
+} from "./ui.tsx"
+import "../tokens.css"
+
+export default {
+  title: "Components / UI primitives",
+} satisfies StoryDefault
+
+function Surface({ children }: { children: ReactNode }) {
+  return <main className="min-h-screen bg-neutral-950 p-6 text-neutral-100">{children}</main>
+}
+
+export const TextPrimitives = () => (
+  <Surface>
+    <div className="flex max-w-[420px] flex-col gap-2">
+      <SectionTitle>Import preview</SectionTitle>
+      <HelperText>
+        変換 notice と conflict choice を同じ画面で見分けやすくするための補助テキストです。
+      </HelperText>
+    </div>
+  </Surface>
+)
+
+TextPrimitives.storyName = "SectionTitle / HelperText"
+
+export const MessageBoxes = () => (
+  <Surface>
+    <div className="flex max-w-[420px] flex-col gap-3">
+      <MessageBox tone="warning">
+        既存のスタイル名と衝突しています。使用するトークンを選択してください。
+      </MessageBox>
+      <MessageBox tone="danger">
+        Framer API timeout
+        {"\n"}
+        既存のカラースタイルを確認できませんでした。
+      </MessageBox>
+    </div>
+  </Surface>
+)
+
+MessageBoxes.storyName = "MessageBox / warning and danger"
+
+export const DialogShell = () => (
+  <Surface>
+    <div className="min-h-[360px]">
+      <DialogBackdrop onClose={action("close-dialog")}>
+        <DialogPanel role="dialog" aria-modal="true" aria-labelledby="catalog-dialog-title">
+          <SectionTitle id="catalog-dialog-title">Import summary</SectionTitle>
+          <HelperText className="mt-2">
+            作成、置換、スキップされたスタイル数をまとめて確認するダイアログの土台です。
+          </HelperText>
+          <DialogActions className="grid-cols-1 sm:grid-cols-2">
+            <ActionButton variant="outline" onClick={action("close-outline")}>
+              Close
+            </ActionButton>
+            <ActionButton onClick={action("confirm")}>Open Framer project</ActionButton>
+          </DialogActions>
+        </DialogPanel>
+      </DialogBackdrop>
+    </div>
+  </Surface>
+)
+
+DialogShell.storyName = "DialogBackdrop / DialogPanel / DialogActions"


### PR DESCRIPTION
## 概要
Issue #12 に対応し、Ladle の component catalog を拡充しました。

## 対応 Issue
- Closes #12

## 変更内容
- `AppHeader` / `LanguageToggle` / `StatsGrid` の story を追加
- `TokenCard` の isolated story を追加
- `JsonTokenEditor` を `focused` / `copied` / `tooltip` / `diagnostic` で確認できるように整理
- `SectionTitle` / `HelperText` / `MessageBox` / `DialogBackdrop` / `DialogPanel` / `DialogActions` の story を追加
- `docs/specs/11-component-catalog.md` に story・fixture・確認観点を反映
- `docs/doc-hub.html` の説明文を更新

## 変更理由
Issue #11 で導入した Ladle catalog を継続運用できるようにし、未登録コンポーネントと interaction 状態を画面で確認しやすくするためです。

## 確認内容
- 追加した story が Framer API 依存を持たず fixture ベースで確認できること
- `JsonTokenEditor` と `TokenCard` の focus ring を story 上で見えること
- catalog ドキュメントが実装済み story と一致していること

### テスト結果
- `npm run check`
- `npm test`
- `npm run catalog:build`

## レビューしてほしい点
- `LanguageToggle` の focus-visible 表現と `22px` thumb の見え方
- `JsonTokenEditor` の copied / tooltip story の切り分け方
- `docs/specs/11-component-catalog.md` の粒度で不足がないか

## 補足
- `gh auth status` はローカルで token invalid でしたが、GitHub connector 経由で draft PR を作成しています。
- issue close は行わず、必要なら後続で issue コメントを追加します.