### PR TITLE
[codex] Document TV-00 validation setup

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -29,6 +29,7 @@
 - Spike
 
   - [Spike README](/spikes/README.md)
+  - [00 Validation Setup](/spikes/00-validation-setup.md)
   - [Spike Template](/spikes/TEMPLATE.md)
   - [01 Color Style Metadata](/spikes/01-color-style-metadata.md)
   - [02 Color Style Linking](/spikes/02-color-style-linking.md)

--- a/docs/doc-hub.html
+++ b/docs/doc-hub.html
@@ -837,6 +837,15 @@
               <p>spike logの役割、親計画、issue運用との関係。</p>
             </div>
           </a>
+          <a class="doc-card compact spike" href="spikes/00-validation-setup.md">
+            <div>
+              <div class="doc-title">
+                <h3>Validation Setup</h3>
+                <span class="badge">TV-00</span>
+              </div>
+              <p>技術検証の共通セットアップ、fixture、Framer project記録先。</p>
+            </div>
+          </a>
           <a class="doc-card compact spike" href="spikes/TEMPLATE.md">
             <div>
               <div class="doc-title">

--- a/docs/issues/technical-validation/README.md
+++ b/docs/issues/technical-validation/README.md
@@ -13,7 +13,7 @@ Issues はこの repo 全体で管理します。
 - Pro / Free のスコープ判断がこの plugin repo の設計に直結する。
 - 別 repo にすると issue、docs、code、decision log が分散する。
 
-検証用 Framer project は、各 spike の `Evidence` や `検証環境` に project 名 / URL / 状態を記録します。
+検証用 Framer project は、まず `docs/spikes/00-validation-setup.md` に project 名 / URL / 状態を記録し、そのうえで各 spike の `Evidence` や `検証環境` に必要な差分を残します。
 
 ## Milestone
 

--- a/docs/issues/technical-validation/TV-00.md
+++ b/docs/issues/technical-validation/TV-00.md
@@ -13,6 +13,7 @@
 ## Steps
 
 - [ ] `docs/spikes/` を作成する
+- [ ] `docs/spikes/00-validation-setup.md` を作成する
 - [ ] 必要なら `src/spikes/` を作成する
 - [ ] 検証用 Framer project を 1 つ用意する
 - [ ] primitive / semantic / broken reference を含む検証用カラーセットを用意する
@@ -28,6 +29,8 @@
 
 - `docs/specs/08-technical-validation-plan.md`
 - `docs/spikes/`
+- `docs/spikes/00-validation-setup.md`
+- `src/fixtures/technical-validation-colors.json`
 - 検証用 Framer project 名 / URL:
 
 ## Decision

--- a/docs/specs/08-technical-validation-plan.md
+++ b/docs/specs/08-technical-validation-plan.md
@@ -468,7 +468,7 @@ GitHub Milestone: Technical Validation      進捗管理
 
 | ID | タスク | 種別 | 優先度 | 成功条件 | 成果物 |
 | --- | --- | --- | --- | --- | --- |
-| TV-00 | 検証環境とログ置き場を準備する | setup | P0 | 検証 project と docs/spikes がある | `docs/spikes/` |
+| TV-00 | 検証環境とログ置き場を準備する | setup | P0 | 検証 project と docs/spikes がある | `docs/spikes/00-validation-setup.md` |
 | TV-01 | Color Style metadata の保存・復元を検証する | spike | P0 | rename / reopen 後も metadata を読める | `docs/spikes/01-color-style-metadata.md` |
 | TV-02 | duplicate / delete 後の metadata 挙動を確認する | spike | P0 | duplicate / delete の仕様判断ができる | `docs/spikes/01-color-style-metadata.md` |
 | TV-03 | primitive / semantic 疑似リンク同期を検証する | spike | P0 | primitive 変更を semantic に反映できる | `docs/spikes/02-color-style-linking.md` |

--- a/docs/spikes/00-validation-setup.md
+++ b/docs/spikes/00-validation-setup.md
@@ -1,0 +1,68 @@
+# Spike: Validation Setup
+
+## Issue
+
+- GitHub Issue: https://github.com/kaonmick/framer-token-plugin/issues/1
+
+## Goal
+
+TV-01 以降の技術検証を、同じ Framer project / fixture / 記録ルールで継続できる状態にする。
+
+## Codex で準備するもの
+
+- `docs/spikes/` を技術検証ログの保存先として使う。
+- `docs/spikes/TEMPLATE.md` を spike 記録テンプレートとして使う。
+- `src/fixtures/technical-validation-colors.json` を検証用カラーセットの初期 fixture として使う。
+- `docs/issues/technical-validation/*.md` を GitHub Issue body file として使う。
+
+## Kaon が決めるもの
+
+- 手動検証に使う Framer project 名
+- 手動検証に使う Framer project URL
+- 検証開始時点の project 状態メモ
+
+## Framer Project Checklist
+
+- [ ] Project name:
+- [ ] Project URL:
+- [ ] 初期状態メモ:
+
+## Validation Fixture
+
+- File: `src/fixtures/technical-validation-colors.json`
+- Contains:
+  - primitive colors
+  - semantic alias colors
+  - broken reference colors
+  - light / dark mode pairs
+
+この fixture を起点にして、TV-01 以降で duplicate / delete / drift / usage scan の派生ケースを追加する。
+
+## Local Commands
+
+```bash
+npm install
+npm run dev
+npm run docs:dev
+npm run check
+npm test
+```
+
+## Success Criteria Mapping
+
+- spike ごとの記録ファイルを作れる
+  - `docs/spikes/TEMPLATE.md`
+  - `docs/spikes/01-color-style-metadata.md` 〜 `06-scale-performance.md`
+- 手動検証に使う Framer project が決まっている
+  - このファイルの `Framer Project Checklist` を埋める
+- 検証用 JSON / Color Styles の初期状態を再現できる
+  - `src/fixtures/technical-validation-colors.json` を使う
+
+## Remaining Manual Step
+
+Codex 側の scaffolding は揃っているため、残作業は Kaon による Framer project の選定と URL 記録です。
+
+## Next Action
+
+- Kaon が Framer project 名 / URL を記入する
+- TV-01 と TV-02 の検証ログをこの setup にぶら下げて記録する

--- a/docs/spikes/README.md
+++ b/docs/spikes/README.md
@@ -12,6 +12,7 @@ Issue 運用:
 
 ## Files
 
+- `00-validation-setup.md` — TV-00
 - `TEMPLATE.md` — spike log template
 - `01-color-style-metadata.md` — TV-01 / TV-02
 - `02-color-style-linking.md` — TV-03
@@ -24,3 +25,4 @@ Issue 運用:
 
 検証結果は issue comment だけに残さず、このディレクトリにも記録します。
 GitHub Issue は作業状態管理、spike log は一次情報と判断履歴の保存場所として扱います。
+`00-validation-setup.md` を TV-00 の canonical な setup log とし、Framer project 名 / URL / fixture 起点をまずここに集約します。

--- a/docs/spikes/TEMPLATE.md
+++ b/docs/spikes/TEMPLATE.md
@@ -10,6 +10,7 @@
 
 ## 検証環境
 
+- Setup log: `docs/spikes/00-validation-setup.md`
 - Framer Plugin SDK version:
 - Framer project:
 - Browser / OS:


### PR DESCRIPTION
## Summary
- add `docs/spikes/00-validation-setup.md` as the canonical TV-00 setup log
- document the shared technical-validation fixture and the remaining Kaon-owned Framer project checklist
- update `docs/spikes/README.md`, `docs/spikes/TEMPLATE.md`, `docs/issues/technical-validation/README.md`, `docs/issues/technical-validation/TV-00.md`, `docs/specs/08-technical-validation-plan.md`, `docs/_sidebar.md`, and `docs/doc-hub.html` so the new setup log is discoverable

## Why
TV-00 had an issue body and downstream spike templates, but it did not yet have a dedicated setup artifact that tied together the fixture, the project recording location, and the remaining manual handoff.

## Impact
- TV-00 now has a concrete deliverable in the repo
- later spikes have a single source of truth for Framer project and fixture setup
- Kaon can fill the remaining project name / URL in one place before TV-01 starts

## Validation
- `git diff --check`
- `npm run check`
- `npm test`

Refs #1