### PR TITLE
editorのデフォルト状態をemptyに変更し、ユーザーへの誘導文言を追加。import後にeditorをリフレッシュ

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -29,7 +29,6 @@ import type {
   ParseWarning,
 } from "../lib/types/tokens.ts"
 import { type Language, messages } from "./i18n.ts"
-import { sampleTokenJson } from "./sample.ts"
 
 const MIN_ACTION_FEEDBACK_MS = 1000
 const CAPTURE_MODES = [
@@ -52,6 +51,11 @@ interface InitialCaptureState {
 }
 
 const initialCaptureMode = getCaptureMode()
+const EMPTY_PARSE_RESULT: ParseColorTokensResult = {
+  tokens: [],
+  conflictGroups: [],
+  warnings: [],
+}
 
 if (!initialCaptureMode) {
   void framer.showUI({
@@ -64,7 +68,7 @@ if (!initialCaptureMode) {
 export function App() {
   const captureMode = useMemo(() => initialCaptureMode, [])
   const initialJsonText = useMemo(() => getInitialJsonText(captureMode), [captureMode])
-  const initialParseResult = useMemo(() => parseColorTokenJson(initialJsonText), [initialJsonText])
+  const initialParseResult = useMemo(() => parseEditorJson(initialJsonText), [initialJsonText])
   const initialCaptureState = useMemo(
     () => getInitialCaptureState(captureMode, initialParseResult),
     [captureMode, initialParseResult]
@@ -102,10 +106,6 @@ export function App() {
   const convertedOklchCount = allTokensForStats.reduce(
     (count, token) => count + (token.format === "oklch" ? 1 : 0) + (token.darkFormat === "oklch" ? 1 : 0),
     0
-  )
-  const lineNumbers = useMemo(
-    () => Array.from({ length: jsonText.split("\n").length }, (_, index) => index + 1),
-    [jsonText]
   )
   const editorDiagnostics = useMemo(
     () => buildEditorDiagnostics(parseResult, language),
@@ -195,7 +195,7 @@ export function App() {
 
   function analyzeJson(nextText = jsonText) {
     startTransition(() => {
-      setParseResult(parseColorTokenJson(nextText))
+      setParseResult(parseEditorJson(nextText))
       setSummary(null)
     })
   }
@@ -226,6 +226,16 @@ export function App() {
   function handleEditorScroll(scrollTop: number) {
     if (!lineNumbersRef.current) return
     lineNumbersRef.current.scrollTop = scrollTop
+  }
+
+  function resetImportSession() {
+    setJsonText("")
+    setParseResult(EMPTY_PARSE_RESULT)
+    setConflicts([])
+    setConflictError(null)
+    setIsCheckingConflicts(false)
+    setConflictSelections(new Map())
+    setSummary(null)
   }
 
   async function runImport() {
@@ -296,8 +306,8 @@ export function App() {
             copyFailed: t.copyJsonFailed,
             resize: t.resizeEditor,
           }}
-          lineNumbers={lineNumbers}
           lineNumbersRef={lineNumbersRef}
+          placeholder={t.editorPlaceholder}
           value={jsonText}
           onScroll={handleEditorScroll}
           onTextChange={handleJsonTextChange}
@@ -369,6 +379,11 @@ export function App() {
                 <DialogActions className="grid-cols-1">
                   <ActionButton
                     onClick={() => {
+                      if (summary.failed === 0) {
+                        resetImportSession()
+                        return
+                      }
+
                       setSummary(null)
                     }}
                   >
@@ -424,8 +439,13 @@ function getInitialJsonText(captureMode: CaptureMode | null): string {
       return conflictManyColorsJson
     case "default":
     case null:
-      return sampleTokenJson
+      return ""
   }
+}
+
+function parseEditorJson(jsonText: string): ParseColorTokensResult {
+  if (jsonText.length === 0) return EMPTY_PARSE_RESULT
+  return parseColorTokenJson(jsonText)
 }
 
 function getInitialCaptureState(

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -14,6 +14,20 @@ export const messages = {
     copyJson: "Copy JSON",
     copiedJson: "JSON copied",
     copyJsonFailed: "Copy failed",
+    editorPlaceholder: `// Upload a JSON file or paste your tokens here
+// Supports W3C Design Tokens format ($type / $value)
+{
+  "color": {
+    "primitive": {
+      "blue": {
+        "500": {
+          "$type": "color",
+          "$value": "#0066ff"
+        }
+      }
+    }
+  }
+}`,
     resizeEditor: "Resize JSON editor height",
     analyze: "Reload",
     analyzing: "Reloading...",
@@ -69,6 +83,20 @@ export const messages = {
     copyJson: "JSONをコピー",
     copiedJson: "JSONをコピーしました",
     copyJsonFailed: "コピーに失敗しました",
+    editorPlaceholder: `// JSONファイルをアップロードするか、ここにトークンを貼り付けてください
+// W3C Design Tokens形式（$type / $value）に対応しています
+{
+  "color": {
+    "primitive": {
+      "blue": {
+        "500": {
+          "$type": "color",
+          "$value": "#0066ff"
+        }
+      }
+    }
+  }
+}`,
     resizeEditor: "JSONエディタの高さを変更",
     analyze: "再読み込み",
     analyzing: "再読み込み中...",

--- a/src/components/JsonTokenEditor.tsx
+++ b/src/components/JsonTokenEditor.tsx
@@ -68,8 +68,8 @@ interface JsonTokenEditorProps {
     copyFailed: string
     resize: string
   }
-  lineNumbers: number[]
   lineNumbersRef: RefObject<HTMLDivElement>
+  placeholder?: string
   value: string
   onScroll: (scrollTop: number) => void
   onTextChange: (value: string) => void
@@ -78,8 +78,8 @@ interface JsonTokenEditorProps {
 export function JsonTokenEditor({
   diagnostics = [],
   labels,
-  lineNumbers,
   lineNumbersRef,
+  placeholder = "",
   value,
   onScroll,
   onTextChange,
@@ -96,9 +96,15 @@ export function JsonTokenEditor({
   const copyTooltipTimerRef = useRef<number | null>(null)
   const resizeCleanupRef = useRef<(() => void) | null>(null)
   const diagnosticsByLine = useMemo(() => groupDiagnosticsByLine(diagnostics), [diagnostics])
+  const isPlaceholderVisible = value.length === 0 && placeholder.length > 0
+  const displayValue = isPlaceholderVisible ? placeholder : value
+  const lineNumbers = useMemo(
+    () => Array.from({ length: displayValue.split("\n").length }, (_, index) => index + 1),
+    [displayValue]
+  )
   const editorPaddingBottom = EDITOR_DEFAULT_PADDING_BOTTOM
   const editorContentHeight = Math.max(editorHeight, lineNumbers.length * EDITOR_LINE_HEIGHT + EDITOR_PADDING_Y + editorPaddingBottom)
-  const editorContentWidth = useMemo(() => getEditorContentWidth(value, diagnosticsByLine), [diagnosticsByLine, value])
+  const editorContentWidth = useMemo(() => getEditorContentWidth(displayValue, diagnosticsByLine), [diagnosticsByLine, displayValue])
 
   useEffect(() => {
     return () => {
@@ -309,7 +315,11 @@ export function JsonTokenEditor({
             className="pointer-events-none absolute inset-0 m-0 overflow-visible whitespace-pre border-0 bg-transparent p-2 font-['Fira_Code','Noto_Sans_JP'] text-[11px] leading-4 text-neutral-100"
             style={{ paddingBottom: editorPaddingBottom }}
           >
-            {renderJsonSyntaxLines(value, diagnosticsByLine, hoveredLine)}
+            {isPlaceholderVisible ? (
+              <span className="text-neutral-400">{displayValue}</span>
+            ) : (
+              renderJsonSyntaxLines(displayValue, diagnosticsByLine, hoveredLine)
+            )}
           </pre>
           <textarea
             className="absolute inset-0 z-[1] h-full w-full resize-none overflow-hidden border-0 bg-transparent p-2 font-['Fira_Code','Noto_Sans_JP'] text-[11px] leading-4 text-transparent caret-yellow-300 selection:bg-yellow-300/25 focus:outline-none"

--- a/src/story/JsonTokenEditor.stories.tsx
+++ b/src/story/JsonTokenEditor.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from "@ladle/react"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import type { StoryDefault } from "@ladle/react"
 import type { ReactNode, RefObject } from "react"
 import type { EditorDiagnostic } from "../components/JsonTokenEditor.tsx"
@@ -9,6 +9,21 @@ import {
   catalogEditorJson,
 } from "./catalog.fixtures.ts"
 import "../tokens.css"
+
+const placeholderJson = `// JSONファイルをアップロードするか、ここにトークンを貼り付けてください
+// W3C Design Tokens形式（$type / $value）に対応しています
+{
+  "color": {
+    "primitive": {
+      "blue": {
+        "500": {
+          "$type": "color",
+          "$value": "#0066ff"
+        }
+      }
+    }
+  }
+}`
 
 export default {
   title: "Components / JsonTokenEditor",
@@ -50,10 +65,6 @@ function EditorStory({
   const [value, setValue] = useState(initialValue)
   const surfaceRef = useRef<HTMLElement>(null)
   const lineNumbersRef = useRef<HTMLDivElement | null>(null)
-  const lineNumbers = useMemo(
-    () => Array.from({ length: value.split("\n").length }, (_, index) => index + 1),
-    [value]
-  )
 
   useEffect(() => {
     if (mode !== "focused") return
@@ -106,8 +117,8 @@ function EditorStory({
       <JsonTokenEditor
         diagnostics={diagnostics}
         labels={editorLabels}
-        lineNumbers={lineNumbers}
         lineNumbersRef={lineNumbersRef}
+        placeholder={placeholderJson}
         value={value}
         onScroll={scrollTop => {
           if (lineNumbersRef.current) {


### PR DESCRIPTION
概要
editor が空のときに、言語別の placeholder JSON を表示するように変更
placeholder は表示専用とし、実際の token data としては扱わないように調整
import 完了 summary の OK クリック後に、editor / conflict / stats を初期化するように変更
確認
editor 入力開始または file upload で placeholder が消えること
placeholder が parse / import 対象にならないこと
import 完了後に OK を押すと、editor が placeholder 表示に戻り、conflict と stats が reset されること