### PR TITLE
Page1 の JSON editor 高さを可変にする

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -323,7 +323,7 @@ export function App() {
 
   return (
     <main
-      className="flex min-h-screen flex-col gap-6 bg-surface-base px-5 pb-28 pt-8 font-['Jost','Noto_Sans_JP'] text-text-default md:gap-16 md:px-16 md:pb-32 md:pt-20"
+      className="flex h-screen min-h-[520px] flex-col gap-6 bg-surface-base px-5 pb-28 pt-8 font-['Jost','Noto_Sans_JP'] text-text-default md:gap-16 md:px-16 md:pb-32 md:pt-20"
       data-capture-mode={captureMode ?? undefined}
       data-ready="true"
       lang={language}
@@ -331,7 +331,7 @@ export function App() {
       <AppHeader language={language} title={t.title} onLanguageChange={setLanguage} />
 
       {currentPage === "editor" ? (
-        <section className="flex flex-col gap-3" aria-label={t.json}>
+        <section className="flex min-h-0 flex-1 flex-col gap-3" aria-label={t.json}>
           <JsonFileDropZone
             labels={{
               button: t.uploadJsonButton,
@@ -343,7 +343,9 @@ export function App() {
           {fileAlert ? <MessageBox tone="danger">{fileAlert}</MessageBox> : null}
 
           <JsonTokenEditor
+            className="min-h-0 flex-1"
             diagnostics={editorDiagnostics}
+            fillAvailableHeight
             labels={{
               copied: t.copiedJson,
               copy: t.copyJson,

--- a/src/components/JsonTokenEditor.tsx
+++ b/src/components/JsonTokenEditor.tsx
@@ -58,7 +58,10 @@ const jsonSyntaxClass: Record<JsonSyntaxKind, string> = {
 }
 
 interface JsonTokenEditorProps {
+  className?: string
   diagnostics?: EditorDiagnostic[]
+  fillAvailableHeight?: boolean
+  height?: number | string
   labels: {
     copy: string
     copied: string
@@ -72,7 +75,10 @@ interface JsonTokenEditorProps {
 }
 
 export function JsonTokenEditor({
+  className,
   diagnostics = [],
+  fillAvailableHeight = false,
+  height = DEFAULT_EDITOR_HEIGHT,
   labels,
   lineNumbersRef,
   placeholder = "",
@@ -80,7 +86,7 @@ export function JsonTokenEditor({
   onScroll,
   onTextChange,
 }: JsonTokenEditorProps) {
-  const editorHeight = DEFAULT_EDITOR_HEIGHT
+  const [measuredEditorHeight, setMeasuredEditorHeight] = useState(DEFAULT_EDITOR_HEIGHT)
   const [copyState, setCopyState] = useState<CopyState>("idle")
   const [isCopyTooltipVisible, setIsCopyTooltipVisible] = useState(false)
   const [copyToastPosition, setCopyToastPosition] = useState<CopyToastPosition | null>(null)
@@ -97,6 +103,7 @@ export function JsonTokenEditor({
   const diagnosticsByLine = useMemo(() => groupDiagnosticsByLine(diagnostics), [diagnostics])
   const isPlaceholderVisible = value.length === 0 && placeholder.length > 0
   const displayValue = isPlaceholderVisible ? placeholder : value
+  const editorHeight = measuredEditorHeight
   const lineNumbers = useMemo(
     () => Array.from({ length: displayValue.split("\n").length }, (_, index) => index + 1),
     [displayValue]
@@ -115,6 +122,25 @@ export function JsonTokenEditor({
       if (copyTooltipTimerRef.current !== null) {
         window.clearTimeout(copyTooltipTimerRef.current)
       }
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    const editorElement = editorRef.current
+    if (!editorElement) return
+
+    function updateMeasuredEditorHeight() {
+      if (!editorElement) return
+      setMeasuredEditorHeight(Math.max(1, editorElement.clientHeight))
+    }
+
+    updateMeasuredEditorHeight()
+
+    const resizeObserver = new ResizeObserver(updateMeasuredEditorHeight)
+    resizeObserver.observe(editorElement)
+
+    return () => {
+      resizeObserver.disconnect()
     }
   }, [])
 
@@ -251,12 +277,12 @@ export function JsonTokenEditor({
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className={`flex flex-col gap-2 ${className ?? ""}`}>
       <div
-        className="relative grid min-h-[180px] w-full grid-cols-[48px_minmax(0,1fr)] overflow-hidden rounded border border-border-default bg-surface-subtle"
+        className={`relative grid min-h-[180px] w-full grid-cols-[48px_minmax(0,1fr)] overflow-hidden rounded border border-border-default bg-surface-subtle ${fillAvailableHeight ? "flex-1" : ""}`}
         data-json-editor="true"
         ref={editorRef}
-        style={{ height: editorHeight }}
+        style={fillAvailableHeight ? undefined : { height }}
       >
         <div
           className="overflow-hidden border-r border-border-muted bg-elevated-default p-2 text-right font-['Fira_Code','Noto_Sans_JP'] text-[11px] leading-4 text-text-subtle select-none"


### PR DESCRIPTION
## 目的

plugin の高さ・幅を可変にしたため、page1 の JSON editor が plugin の高さに合わせて伸びるようにします。

## 変更内容

- page1 の editor 領域を残り高さに合わせて伸びる layout に変更
- main の padding は維持
- JsonTokenEditor に親の高さへ追従する option を追加
- editor 実測高さを使って診断マーカーと tooltip 位置を維持

## 確認

- npm run check
- npm run build
- git diff --check
- 簡易 Framer host + Playwright で 620px / 820px の editor 高さ追従を確認

対象 commit: a9738be