### PR TITLE
Support rootless aliases and preview scroll reset

### DIFF
--- a/docs/marketplace-assets/description.md
+++ b/docs/marketplace-assets/description.md
@@ -4,41 +4,26 @@ Framer Marketplace の plugin 申請画面へ貼り付ける文面です。
 
 公開文言は、現在実装済みの color token import に限定します。spacing、typography、radius、project-wide audit、sync、variables manager は含めません。
 
-## Plugin Name
 
+## Plugin Name
 Json Color Importer
 
+
 ## Tagline
+Color tokens from JSON
 
-```text
-Color tokens from JSON / 色取込
-```
-
-- 文字数: 30 / 30
 
 ## Summary
-
-```text
 No more rebuilding color styles by hand. Paste your JSON token file and import directly into Framer Color Styles — with light/dark, color preview, and conflict handling.
 
-カラースタイルをFramerで一から再現する手間をなくします。JSONを貼り付けるだけでカラースタイルへ直接取り込み。ライト/ダーク、カラープレビュー、コンフリクト選択に対応。
-```
-
-- 文字数: 約 243 / 260
 
 ## Description
-
-```text
 Json Color Importer lets individuals and teams bring their JSON color tokens into Framer Color Styles with minimal steps.
 
 If you already store colors as design tokens in a JSON file — from a token pipeline, Tokens Studio, or a shared design system repository — this plugin imports them directly into Framer and keeps your Color Styles organized without manual re-entry.
 
-Json Color Importerは、個人やチームのJSONで管理しているカラートークンをFramer カラースタイルへ簡単に取り込むためのプラグインです。Tokens StudioやToken pipelineなど、すでにJSONでデザイントークンを管理している場合は最小限のステップでカラースタイルを整理できます。
 
----
-
-### What it supports / 対応内容
-
+### What it supports
 Primitive color tokens ($type: "color" with $value)
 Semantic alias tokens that reference other color tokens
 Light and dark theme values mapped to Framer Color Style themes
@@ -47,6 +32,20 @@ Conflict handling — choose skip or replace for each existing Color Style
 Import summary showing created, replaced, skipped, and failed counts
 English and Japanese UI
 
+### Known behavior
+Alias tokens resolve only when the referenced token exists in the same file.
+Conflicts with existing Color Styles require a manual choice before importing — existing styles are kept by default.
+OKLCH values are converted to rgba for Framer compatibility.
+Dark-only tokens without a matching light value are imported as regular styles.
+
+
+<!-- 日本語ver -->
+## Description
+カラースタイルをFramerで一から再現する手間をなくします。JSONを貼り付けるだけでカラースタイルへ直接取り込み。ライト/ダーク、カラープレビュー、コンフリクト選択に対応。
+
+Json Color Importerは、個人やチームのJSONで管理しているカラートークンをFramer カラースタイルへ簡単に取り込むためのプラグインです。Tokens StudioやToken pipelineなど、すでにJSONでデザイントークンを管理している場合は最小限のステップでカラースタイルを整理できます。
+
+### 対応内容
 $type: "color" と $value を持つプリミティブカラートークン
 他のカラートークンを参照するセマンティックエイリアス
 ライト / ダークテーマ値をFramer カラースタイルのテーマへマッピング
@@ -55,27 +54,21 @@ $type: "color" と $value を持つプリミティブカラートークン
 インポート後のサマリー（作成・更新・スキップ・失敗数）
 英語 / 日本語の言語切り替え
 
----
-
-Scope of this release:
-
-Color token import only. This release does not cover spacing, typography, border radius, project-wide audits, syncing, or a variables manager.
-
-このリリースはcolor token importのみです。spacing、typography、radius、audit、sync、variables managerは対象外です。
-
----
-
-Known behavior / 既知の挙動
-Alias tokens resolve only when the referenced token exists in the same file.
-Conflicts with existing Color Styles require a manual choice before importing — existing styles are kept by default.
-OKLCH values are converted to rgba for Framer compatibility.
-Dark-only tokens without a matching light value are imported as regular styles.
-
+### 既知の挙動
 エイリアスは参照先トークンが同じファイル内に存在する場合のみ解決します。
 既存カラースタイルとのコンフリクトは、インポート前にどのカラートークンをインポートするかを手動で選ぶ必要があります（デフォルトは既存のトークンが選択されます）。
 OKLCHはFramer互換性のためrgbaへ変換します。
 対応するライトモードがないダークのみのトークンは通常スタイルとしてインポートされます。
-```
+
+
+## Support
+
+If you have questions, bug reports, or feedback about Json Color Importer, please contact us through this form. We usually review messages within a few business days.
+
+Json Color Importer support form:
+https://forms.gle/...
+
+---
 
 ## Review Instructions
 
@@ -114,9 +107,4 @@ Scope: color tokens only. No spacing, typography, radius, audit, sync, or variab
 
 - 文字数: 約 970 / 1000
 
-## 変更メモ
 
-- tagline: 「Color tokens from JSON」でデザインシステムユーザーへの訴求を強化し、日本語「色取込」を添えて30文字ちょうど
-- summary: 「No more rebuilding by hand」という課題起点の訴求に変更。機能列挙より「何を解決するか」を前面に
-- description: Who this is for（ターゲット）→ The problem → Features → Scope → Known behavior の構成に整理。チームでトークン管理しているユーザー像を明示
-- Review Instructions: 4つのテストシナリオ（基本・light/dark・conflict・エラー）に分けて番号を連番化。各テストに日本語サマリーを追加

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -129,6 +129,20 @@ export function App() {
 
   useEffect(() => syncDocumentThemeFromFramer(document), [])
 
+  useEffect(() => {
+    if (currentPage !== "preview") return
+
+    const frame = window.requestAnimationFrame(() => {
+      window.scrollTo(0, 0)
+      document.documentElement.scrollTop = 0
+      document.body.scrollTop = 0
+    })
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+    }
+  }, [currentPage])
+
   // Initialize conflict selections when parse result changes
   useEffect(() => {
     setConflictSelections(prev => {
@@ -323,7 +337,7 @@ export function App() {
 
   return (
     <main
-      className="flex h-screen min-h-[520px] flex-col gap-6 bg-surface-base px-5 pb-28 pt-8 font-['Jost','Noto_Sans_JP'] text-text-default md:gap-16 md:px-16 md:pb-32 md:pt-20"
+      className="flex min-h-screen flex-col gap-6 bg-surface-base px-5 pb-28 pt-8 font-['Jost','Noto_Sans_JP'] text-text-default md:gap-16 md:px-16 md:pb-32 md:pt-20"
       data-capture-mode={captureMode ?? undefined}
       data-ready="true"
       lang={language}

--- a/src/lib/parser/colorTokenParser.ts
+++ b/src/lib/parser/colorTokenParser.ts
@@ -225,7 +225,7 @@ function resolveColorToken(
   const aliasPath = readAliasPath(token.value)
 
   if (aliasPath) {
-    const aliasTarget = tokensByPath.get(aliasPath) ?? findModeScopedAliasTarget(token, aliasPath, tokensByPath)
+    const aliasTarget = findAliasTarget(token, aliasPath, tokensByPath, warnings)
 
     if (!aliasTarget) {
       warnings.push({
@@ -596,6 +596,28 @@ function asPlainToken(token: ResolvedRawColorToken): ResolvedRawColorToken {
   }
 }
 
+function findAliasTarget(
+  token: RawColorToken,
+  aliasPath: string,
+  tokensByPath: Map<string, RawColorToken>,
+  warnings: ParseWarning[]
+): RawColorToken | undefined {
+  const exactTarget = tokensByPath.get(aliasPath) ?? findModeScopedAliasTarget(token, aliasPath, tokensByPath)
+  if (exactTarget) return exactTarget
+
+  const relativeTarget = findRelativeAliasTarget(aliasPath, tokensByPath)
+  if (relativeTarget === "ambiguous") {
+    warnings.push({
+      code: "unresolved-alias",
+      path: token.sourcePath,
+      message: `Alias target "${aliasPath}" matched multiple tokens.`,
+    })
+    return undefined
+  }
+
+  return relativeTarget
+}
+
 function findModeScopedAliasTarget(
   token: RawColorToken,
   aliasPath: string,
@@ -616,6 +638,20 @@ function findModeScopedAliasTarget(
   ])
 
   return tokensByPath.get(modeScopedPath)
+}
+
+function findRelativeAliasTarget(
+  aliasPath: string,
+  tokensByPath: Map<string, RawColorToken>
+): RawColorToken | "ambiguous" | undefined {
+  const suffix = `.${aliasPath}`
+  const matches = [...tokensByPath.entries()]
+    .filter(([sourcePath]) => sourcePath.endsWith(suffix))
+    .map(([, token]) => token)
+
+  if (matches.length === 0) return undefined
+  if (matches.length > 1) return "ambiguous"
+  return matches[0]
 }
 
 function readColorMode(path: string[]): { mode: ColorTokenMode; index: number } | null {

--- a/tests/colorTokenParser.test.ts
+++ b/tests/colorTokenParser.test.ts
@@ -206,6 +206,49 @@ describe("parseColorTokenJson", () => {
     })
   })
 
+  it("resolves rootless semantic aliases to primitive tokens", () => {
+    const result = parseColorTokenJson(`{
+      "primitive": {
+        "slate": {
+          "100": {
+            "value": "#f1f5f9",
+            "type": "color"
+          },
+          "900": {
+            "value": "#0f172a",
+            "type": "color"
+          }
+        }
+      },
+      "semantic": {
+        "background": {
+          "value": {
+            "light": "{slate.100}",
+            "dark": "{slate.900}"
+          },
+          "type": "color"
+        }
+      },
+      "primitive/alpha": {},
+      "$metadata": {
+        "tokenSetOrder": ["primitive", "primitive/alpha", "semantic"]
+      }
+    }`)
+
+    const backgroundToken = result.tokens.find(token => token.styleName === "semantic/background")
+
+    expect(result.warnings).toHaveLength(0)
+    expect(backgroundToken).toMatchObject({
+      sourcePath: "semantic.background.light",
+      darkSourcePath: "semantic.background.dark",
+      value: "rgba(241, 245, 249, 1)",
+      darkValue: "rgba(15, 23, 42, 1)",
+      aliasPath: "primitive.slate.100",
+      darkAliasPath: "primitive.slate.900",
+      modes: ["light", "dark"],
+    })
+  })
+
   it("keeps a dark-only token as a separate style with a warning", () => {
     const result = parseColorTokenJson(`{
       "color": {


### PR DESCRIPTION
## 概要

- rootを省略したalias（例: `{slate.100}`）をprimitive tokenへ解決できるように修正
- preview画面のスクロール位置と下部余白を調整
- Marketplace申請文面を整理

## 確認

- npm test
- npm run pack